### PR TITLE
Adds more constraints on the DB

### DIFF
--- a/src/database/db_build.sql
+++ b/src/database/db_build.sql
@@ -27,10 +27,10 @@ CREATE TABLE IF NOT EXISTS  businesses
   business_type VARCHAR (100) NOT NULL,
   phone VARCHAR (50) NOT NULL,
   address VARCHAR (100) NOT NULL,
-  email VARCHAR(100),
-  parking  BOOLEAN ,
-  freeWifi  BOOLEAN ,
-  smokingArea  BOOLEAN,
+  email VARCHAR(100) NOT NULL,
+  parking  BOOLEAN DEFAULT FALSE NOT NULL,
+  freeWifi  BOOLEAN DEFAULT FALSE NOT NULL,
+  smokingArea  BOOLEAN DEFAULT FALSE NOT NULL,
   created_at TIMESTAMP DEFAULT NOW(),
   updated_at TIMESTAMP DEFAULT NOW(),
   FOREIGN KEY (user_id)REFERENCES users (id)
@@ -45,7 +45,8 @@ CREATE TABLE IF NOT EXISTS  images
    active BOOLEAN DEFAULT TRUE,
    created_at TIMESTAMP DEFAULT NOW(),
    updated_at TIMESTAMP DEFAULT NOW(),
-   FOREIGN KEY (business_id) REFERENCES businesses (id)
+   FOREIGN KEY (business_id) REFERENCES businesses (id),
+  UNIQUE (business_id,image_url)
 );
 
 


### PR DESCRIPTION
In images, the combination business_id and image should be unique,this will prevent bad implementations where we spam add the same images (you cant add dupicates which is a file by the same user uploaded the same image(same file name) at the same time , this can also happen when we make double post requests and such.
In businesses , added default values for parking,freewifi,smoking area as false, and not null constraints, because if somehow those values are null the website will crash.